### PR TITLE
Add tooling setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore logs and temporary build files
+cscope.out
+*.log

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+apt-get update
+apt-get install -y clang-14 clang-tools-14 gcc-multilib cscope cloc npm python3-pip
+pip3 install lizard
+npm install -g tree-sitter-cli


### PR DESCRIPTION
## Summary
- create `.gitignore`
- add `setup.sh` script for installing clang, analysis tools and dependencies

## Testing
- `apt-get update`
- `apt-get install -y clang-14 clang-tools-14 cscope cloc npm python3-pip`
- `pip3 install lizard`
- `npm install -g tree-sitter-cli`
- `cloc .`
- `lizard`
- `cscope -Rb`


------
https://chatgpt.com/codex/tasks/task_e_6858e9faa89c83318f17656a37cde60a