### PR TITLE
Improve modern flcopy example

### DIFF
--- a/modern/Makefile
+++ b/modern/Makefile
@@ -1,0 +1,18 @@
+CC ?= gcc
+# Aggressively optimize for the host machine while remaining
+# standards compliant.  Security hardening options and link-time
+# optimization further reduce the binary footprint.
+CFLAGS ?= -Wall -Wextra -pedantic -std=c99 -O3 -march=native -flto -fPIE -fno-plt \
+       -pipe -fstack-protector-strong -D_FORTIFY_SOURCE=2
+LDFLAGS ?= -flto -fstack-protector-strong -Wl,-O1 -Wl,--as-needed -fno-plt \
+       -fPIE -pie -Wl,--no-undefined -Wl,-z,relro -Wl,-z,now
+
+all: flcopy
+
+flcopy: flcopy.c
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+clean:
+	rm -f flcopy
+
+.PHONY: all clean

--- a/modern/README-modern.md
+++ b/modern/README-modern.md
@@ -1,0 +1,50 @@
+# Modern Build Example
+
+This repository preserves the Research Unix Version 8 source tree.
+To demonstrate building a small utility with a modern toolchain, the
+`modern/` directory contains a cleaned up version of `flcopy.c`.
+
+```
+cd modern
+make
+```
+
+The resulting binary `flcopy` links against standard C libraries and
+uses aggressive optimization including link-time optimization.
+The Makefile uses an aggressive set of optimization and hardening flags:
+
+* `-O3` and `-march=native` tune the code for the host CPU
+* `-flto` enables link-time optimization for smaller binaries
+* `-pipe` streams intermediate results through pipes
+* `-fPIE` and the linker option `-pie` produce a position independent executable
+* `-fno-plt` avoids the PLT for faster, safer calls
+* `-fstack-protector-strong` and `-D_FORTIFY_SOURCE=2` add stack smashing guards
+* `-Wl,--no-undefined` ensures all symbols resolve at link time
+* `-Wl,-z,relro` and `-Wl,-z,now` enforce immediate relocation binding
+
+All of these flags combine to produce a secure, optimized utility.
+The floppy device may be specified with the `-d` flag:
+
+```sh
+./flcopy -d /dev/fd0
+```
+
+Run `./flcopy --help` (or `-H`) for a summary of options.
+
+## Testing the build
+
+`test-flcopy.sh` rebuilds the program and verifies that PIE,
+stack-protector support, and that no spurious PLT calls remain:
+
+```sh
+./test-flcopy.sh
+```
+
+### Analyzing complexity
+
+The setup script installs the `lizard` tool. Run it to review function
+complexity metrics:
+
+```sh
+lizard flcopy.c
+```

--- a/modern/flcopy.c
+++ b/modern/flcopy.c
@@ -1,0 +1,179 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+#include <ctype.h>
+#include <getopt.h>
+
+/**
+ * Modernized floppy copy utility derived from Research Unix v8.
+ * This version compiles cleanly with modern C compilers and
+ * demonstrates basic block-level copy between a floppy device
+ * and an image file. It preserves the original algorithm but
+ * uses ANSI C prototypes and standard headers.
+ */
+
+static int floppydes = -1;
+static const char *flopname = "/dev/floppy";
+static long dsize = 77L * 26 * 128; /* default size in bytes */
+static int hflag = 0; /* half-time flag */
+static int rflag = 0; /* read-only flag */
+
+static void usage(const char *progname);
+static void rt_init(void);
+static long trans(int logical);
+static void lread(int startad, int count, char *obuff);
+static void lwrite(int startad, int count, char *obuff);
+
+int main(int argc, char **argv) {
+    char buff[512];
+    long count;
+    int startad = -26 * 128;
+    int n, file = -1;
+    int opt;
+    static const struct option long_opts[] = {
+        {"help",  no_argument,       0, 'H'},
+        {0,       0,                 0, 0}
+    };
+
+    while ((opt = getopt_long(argc, argv, "d:hrt:H", long_opts, NULL)) != -1) {
+        switch (opt) {
+        case 'H':
+            usage(argv[0]);
+            return 0;
+        case 'd':
+            flopname = optarg;
+            break;
+        case 'h':
+            hflag = 1;
+            break;
+        case 'r':
+            rflag = 1;
+            break;
+        case 't':
+            dsize = atol(optarg);
+            if (dsize <= 0 || dsize > 77) {
+                fprintf(stderr, "Bad number of tracks\n");
+                return 2;
+            }
+            dsize *= 26 * 128;
+            break;
+        default:
+            usage(argv[0]);
+            return 1;
+        }
+    }
+    if (optind != argc) {
+        usage(argv[0]);
+        return 1;
+    }
+    if (hflag) {
+        printf("Halftime!\n");
+        file = open("floppy", O_RDONLY);
+        if (file < 0) {
+            perror("failed to open floppy image for reading");
+            return 1;
+        }
+    }
+
+    if (!hflag) {
+        file = creat("floppy", 0666);
+        (void)close(file);
+        file = open("floppy", O_RDWR);
+        if (file < 0) {
+            perror("failed to open floppy image");
+            return 1;
+        }
+        for (count = dsize; count > 0; count -= 512) {
+            n = count > 512 ? 512 : (int)count;
+            lread(startad, n, buff);
+            if (write(file, buff, n) != n) {
+                perror("write");
+                return 1;
+            }
+            startad += 512;
+        }
+    }
+
+    if (rflag) return 0;
+    printf("Change Floppy, hit return when done.\n");
+    if (fgets(buff, sizeof(buff), stdin) == NULL) {
+        perror("fgets");
+        return 1;
+    }
+    (void)lseek(file, 0, SEEK_SET);
+    count = dsize; startad = -26 * 128;
+    for (; count > 0; count -= 512) {
+        n = count > 512 ? 512 : (int)count;
+        if (read(file, buff, n) != n) {
+            perror("read");
+            return 1;
+        }
+        lwrite(startad, n, buff);
+        startad += 512;
+    }
+    return 0;
+}
+
+static void rt_init(void) {
+    static int initialized = 0;
+    int mode = O_RDWR;
+    if (initialized) return;
+    if (rflag) mode = O_RDONLY;
+    initialized = 1;
+    floppydes = open(flopname, mode);
+    if (floppydes < 0) {
+        perror("Floppy open failed");
+        exit(1);
+    }
+}
+
+static long trans(int logical) {
+    /* Logical to physical address translation */
+    int sector, bytes, track;
+    logical += 26 * 128;
+    bytes = logical & 127;
+    logical >>= 7;
+    sector = logical % 26;
+    if (sector >= 13)
+        sector = sector * 2 + 1;
+    else
+        sector *= 2;
+    sector += 26 + ((track = (logical / 26)) - 1) * 6;
+    sector %= 26;
+    return (((track * 26) + sector) << 7) + bytes;
+}
+
+static void lread(int startad, int count, char *obuff) {
+    rt_init();
+    while ((count -= 128) >= 0) {
+        if (lseek(floppydes, trans(startad), SEEK_SET) < 0 ||
+            read(floppydes, obuff, 128) != 128) {
+            perror("floppy read");
+            exit(1);
+        }
+        obuff += 128;
+        startad += 128;
+    }
+}
+
+static void lwrite(int startad, int count, char *obuff) {
+    rt_init();
+    while ((count -= 128) >= 0) {
+        if (lseek(floppydes, trans(startad), SEEK_SET) < 0 ||
+            write(floppydes, obuff, 128) != 128) {
+            perror("floppy write");
+            exit(1);
+        }
+        obuff += 128;
+        startad += 128;
+    }
+}
+
+static void usage(const char *progname) {
+    fprintf(stderr,
+            "Usage: %s [-d device] [-h] [-r] [-t tracks]\n",
+            progname);
+}
+

--- a/modern/test-flcopy.sh
+++ b/modern/test-flcopy.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Simple build test verifying hardened flags in flcopy
+set -e
+
+make clean
+make
+
+# Ensure the binary is a PIE
+if ! readelf -h flcopy | grep -q "Type:.*DYN"; then
+    echo "flcopy is not built as PIE" >&2
+    exit 1
+fi
+
+# Ensure stack protector symbols are present
+if ! readelf -s flcopy | grep -q "__stack_chk_fail"; then
+    echo "Stack protector not enabled" >&2
+    exit 1
+fi
+
+# Verify RELRO and BIND_NOW
+if ! readelf -l flcopy | grep -q "GNU_RELRO"; then
+    echo "RELRO not enabled" >&2
+    exit 1
+fi
+
+if ! readelf -d flcopy | grep -q "BIND_NOW"; then
+    echo "BIND_NOW not enabled" >&2
+    exit 1
+fi
+
+# Ensure no PLT calls except for the startup handler
+if objdump -d flcopy | grep -E "@plt>" | grep -v "__cxa_finalize" >/dev/null; then
+    echo "Unexpected PLT calls detected" >&2
+    exit 1
+fi
+
+echo "flcopy passes hardening checks."

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,7 @@ set -e
 sudo apt-get update
 
 # Install build tools and analysis utilities
-sudo apt-get install -y clang-14 build-essential cscope cloc npm python3-pip
+sudo apt-get install -y clang build-essential cscope cloc npm python3-pip
 
 # Node-based tree-sitter CLI
 sudo npm install -g tree-sitter-cli


### PR DESCRIPTION
## Summary
- document complexity tool and warn about PLT references
- verify absence of PLT calls in `test-flcopy.sh`

## Testing
- `bash setup.sh`
- `cd modern && make clean && make`
- `cd modern && ./test-flcopy.sh`


------
https://chatgpt.com/codex/tasks/task_e_68595c96dea08331a7fa3fd09a29c6cb